### PR TITLE
Add support for generic relationships

### DIFF
--- a/seal/models.py
+++ b/seal/models.py
@@ -1,3 +1,4 @@
+from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.utils.six import with_metaclass
 
@@ -5,7 +6,9 @@ from .exceptions import SealedObject
 from .managers import SealableQuerySet
 from .related import (
     create_sealable_m2m_contribute_to_class,
-    create_sealable_m2m_contribute_to_related_class, sealable_accessor_classes,
+    create_sealable_m2m_contribute_to_related_class,
+    create_sealable_reverse_generic_contribute_to_class,
+    sealable_accessor_classes,
 )
 
 
@@ -13,6 +16,8 @@ class SealaleModelBase(models.base.ModelBase):
     def __new__(cls, name, bases, attrs):
         for attr, value in attrs.items():
             if isinstance(value, models.ForeignObject):
+                if isinstance(value, GenericRelation):
+                    value.contribute_to_class = create_sealable_reverse_generic_contribute_to_class(value)
                 sealable_accessor_class = sealable_accessor_classes.get(value.related_accessor_class)
                 if sealable_accessor_class:
                     value.related_accessor_class = sealable_accessor_class

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,11 +1,24 @@
+from django.contrib.contenttypes.fields import (
+    GenericForeignKey, GenericRelation,
+)
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from seal.managers import SealableQuerySet
 from seal.models import SealableModel
 
 
+class Nickname(SealableModel):
+    name = models.CharField(max_length=24)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+    object_id = models.PositiveIntegerField()
+    content_object = GenericForeignKey('content_type', 'object_id')
+
+
 class Location(SealableModel):
     latitude = models.FloatField()
     longitude = models.FloatField()
+
+    nicknames = GenericRelation(Nickname, related_query_name='locations')
 
 
 class SeaLion(SealableModel):
@@ -13,6 +26,8 @@ class SeaLion(SealableModel):
     weight = models.PositiveIntegerField()
     location = models.ForeignKey(Location, models.CASCADE, null=True, related_name='visitors')
     previous_locations = models.ManyToManyField(Location, related_name='previous_visitors')
+
+    nicknames = GenericRelation(Nickname, related_query_name='sealions')
 
 
 class GreatSeaLion(SeaLion):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -11,6 +11,7 @@ DATABASES = {
 }
 
 INSTALLED_APPS = [
+    'django.contrib.contenttypes',
     'seal',
     'tests',
 ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,7 @@
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 from seal.exceptions import SealedObject
 
-from .models import GreatSeaLion, Location, SeaLion
+from .models import GreatSeaLion, Location, Nickname, SeaLion
 
 
 class SealableModelTests(SimpleTestCase):
@@ -53,3 +53,21 @@ class SealableModelTests(SimpleTestCase):
         message = "Cannot fetch many-to-many field previous_visitors on a sealed object."
         with self.assertRaisesMessage(SealedObject, message):
             instance.previous_visitors.all()
+
+
+class ContentTypeSealableModelTests(TestCase):
+    # ContentType framework requires DB queries to be enabled so we can't use SimpleTestCase
+
+    def test_sealed_instance_generic_relationship_access(self):
+        instance = SeaLion.from_db('default', ['id'], [1])
+        instance._state.sealed = True
+        message = "Cannot fetch many-to-many field nicknames on a sealed object."
+        with self.assertRaisesMessage(SealedObject, message):
+            instance.nicknames.all()
+
+    def test_sealed_instance_reverse_generic_relationship_access(self):
+        instance = Nickname.from_db('default', ['id', 'name'], [1, 'Lester'])
+        instance._state.sealed = True
+        message = "Cannot fetch many-to-many field sealions on a sealed object."
+        with self.assertRaisesMessage(SealedObject, message):
+            instance.sealions.all()


### PR DESCRIPTION
Addresses https://github.com/charettes/django-seal/issues/10.

Had a funny case where `ContentType` caching blew up `SimpleTestCase` for making db calls but just swapped to `TestCase`. My Django-fu is too weak to warm that cache compared to how easy it is to swap out the test case! 😛 
  