### PR TITLE
Issue warnings on unsealed attributes accesses instead of exceptions.

### DIFF
--- a/seal/descriptors.py
+++ b/seal/descriptors.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import warnings
+
 from django.contrib.contenttypes.fields import (
     GenericForeignKey, ReverseGenericManyToOneDescriptor,
 )
@@ -25,9 +27,10 @@ def create_sealable_related_manager(related_manager_cls, field_name):
                 try:
                     return self.instance._prefetched_objects_cache[prefetch_cache_name]
                 except (AttributeError, KeyError):
-                    raise UnsealedAttributeAccess('Cannot fetch many-to-many field %s on sealed %s.' % (
+                    message = 'Cannot fetch many-to-many field %s on sealed %s.' % (
                         field_name, self.instance,
-                    ))
+                    )
+                    warnings.warn(message, category=UnsealedAttributeAccess, stacklevel=3)
             return super(SealableRelatedManager, self).get_queryset()
     return SealableRelatedManager
 
@@ -39,7 +42,8 @@ class SealableDeferredAttribute(DeferredAttribute):
         if (getattr(instance._state, 'sealed', False) and
             instance.__dict__.get(self.field_name, self) is self and
                 self._check_parent_chain(instance, self.field_name) is None):
-            raise UnsealedAttributeAccess('Cannot fetch deferred field %s on sealed %s.' % (self.field_name, instance))
+            message = 'Cannot fetch deferred field %s on sealed %s.' % (self.field_name, instance)
+            warnings.warn(message, category=UnsealedAttributeAccess, stacklevel=2)
         return super(SealableDeferredAttribute, self).__get__(instance, cls)
 
 
@@ -57,13 +61,11 @@ class SealableForwardOneToOneDescriptor(ForwardOneToOneDescriptor):
                 # If any of the related model's fields are deferred, prevent
                 # the query from being performed.
                 if any(field in fields for field in deferred):
-                    raise UnsealedAttributeAccess(
-                        'Cannot fetch related field %s on sealed %s.' % (self.field.name, instance)
-                    )
+                    message = 'Cannot fetch related field %s on sealed %s.' % (self.field.name, instance)
+                    warnings.warn(message, category=UnsealedAttributeAccess, stacklevel=3)
             else:
-                raise UnsealedAttributeAccess(
-                    'Cannot fetch related field %s on sealed %s.' % (self.field.name, instance)
-                )
+                message = 'Cannot fetch related field %s on sealed %s.' % (self.field.name, instance)
+                warnings.warn(message, category=UnsealedAttributeAccess, stacklevel=3)
         parent = super(SealableForwardOneToOneDescriptor, self).get_object(instance)
         if parent:
             parent.seal()
@@ -73,16 +75,16 @@ class SealableForwardOneToOneDescriptor(ForwardOneToOneDescriptor):
 class SealableReverseOneToOneDescriptor(ReverseOneToOneDescriptor):
     def get_queryset(self, instance, **hints):
         if getattr(instance._state, 'sealed', False):
-            raise UnsealedAttributeAccess(
-                'Cannot fetch related field %s on sealed %s.' % (self.related.name, instance)
-            )
+            message = 'Cannot fetch related field %s on sealed %s.' % (self.related.name, instance)
+            warnings.warn(message, category=UnsealedAttributeAccess, stacklevel=3)
         return super(SealableReverseOneToOneDescriptor, self).get_queryset(instance=instance, **hints)
 
 
 class SealableForwardManyToOneDescriptor(ForwardManyToOneDescriptor):
     def get_object(self, instance):
         if getattr(instance._state, 'sealed', False):
-            raise UnsealedAttributeAccess('Cannot fetch related field %s on sealed %s.' % (self.field.name, instance))
+            message = 'Cannot fetch related field %s on sealed %s.' % (self.field.name, instance)
+            warnings.warn(message, category=UnsealedAttributeAccess, stacklevel=3)
         return super(SealableForwardManyToOneDescriptor, self).get_object(instance)
 
 
@@ -107,7 +109,8 @@ class SealableGenericForeignKey(GenericForeignKey):
             return self
 
         if getattr(instance._state, 'sealed', False) and not self.is_cached(instance):
-            raise UnsealedAttributeAccess('Cannot fetch related field %s on sealed %s.' % (self.name, instance))
+            message = 'Cannot fetch related field %s on sealed %s.' % (self.name, instance)
+            warnings.warn(message, category=UnsealedAttributeAccess, stacklevel=2)
 
         return super(SealableGenericForeignKey, self).__get__(instance, cls=cls)
 

--- a/seal/exceptions.py
+++ b/seal/exceptions.py
@@ -1,2 +1,2 @@
-class UnsealedAttributeAccess(AttributeError):
+class UnsealedAttributeAccess(AttributeError, Warning):
     pass

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 from django.core import checks
@@ -12,6 +14,10 @@ from .models import GreatSeaLion, Location, Nickname, SeaGull, SeaLion
 
 
 class SealableModelTests(SimpleTestCase):
+    def setUp(self):
+        warnings.filterwarnings('error', category=UnsealedAttributeAccess)
+        self.addCleanup(warnings.resetwarnings)
+
     def test_sealed_instance_deferred_attribute_access(self):
         instance = SeaLion.from_db('default', ['id'], [1])
         instance.seal()
@@ -90,6 +96,10 @@ class ContentTypesSealableModelTests(TestCase):
     def setUpTestData(cls):
         tests_models = tuple(apps.get_app_config('tests').get_models())
         ContentType.objects.get_for_models(*tests_models, for_concrete_models=True)
+
+    def setUp(self):
+        warnings.filterwarnings('error', category=UnsealedAttributeAccess)
+        self.addCleanup(warnings.resetwarnings)
 
     def test_sealed_instance_generic_foreign_key(self):
         instance = Nickname.from_db('default', ['id', 'content_type_id', 'object_id'], [1, 1, 1])

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Prefetch
@@ -21,6 +23,10 @@ class SealableQuerySetTests(TestCase):
         cls.nickname = Nickname.objects.create(name='Jonathan Livingston', content_object=cls.gull)
         tests_models = tuple(apps.get_app_config('tests').get_models())
         ContentType.objects.get_for_models(*tests_models, for_concrete_models=True)
+
+    def setUp(self):
+        warnings.filterwarnings('error', category=UnsealedAttributeAccess)
+        self.addCleanup(warnings.resetwarnings)
 
     def test_state_sealed_assigned(self):
         instance = SeaLion.objects.seal().get()


### PR DESCRIPTION
This will allow logging to take place and easy escalation to exceptions using `warnings.filterwarnings('error', category=UnsealedAttributeAccess)`.