### PR TITLE
Fix for __repr__/__unicode__ recursion bug.

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -2,8 +2,8 @@ from django.contrib.contenttypes.fields import (
     GenericForeignKey, GenericRelation,
 )
 from django.contrib.contenttypes.models import ContentType
-from django.utils.encoding import python_2_unicode_compatible
 from django.db import models
+from django.utils.encoding import force_text, python_2_unicode_compatible
 from seal.models import SealableModel
 
 
@@ -37,10 +37,10 @@ class SeaLion(SealableModel):
     leak = models.ForeignKey(Leak, models.CASCADE, null=True)
 
     def __str__(self):
-        return repr(self)
+        return force_text(repr(self))
 
     def __repr__(self):
-        return '<SeaLion %s %s %s>' % (self.id, self.height, self.weight)
+        return str('<SeaLion %s %s %s>' % (self.id, self.height, self.weight))
 
 
 class SeaLionAbstractSubclass(SeaLion):

--- a/tests/models.py
+++ b/tests/models.py
@@ -2,6 +2,7 @@ from django.contrib.contenttypes.fields import (
     GenericForeignKey, GenericRelation,
 )
 from django.contrib.contenttypes.models import ContentType
+from django.utils.encoding import python_2_unicode_compatible
 from django.db import models
 from seal.models import SealableModel
 
@@ -27,12 +28,19 @@ class Leak(models.Model):
     description = models.TextField()
 
 
+@python_2_unicode_compatible
 class SeaLion(SealableModel):
     height = models.PositiveIntegerField()
     weight = models.PositiveIntegerField()
     location = models.ForeignKey(Location, models.CASCADE, null=True, related_name='visitors')
     previous_locations = models.ManyToManyField(Location, related_name='previous_visitors')
     leak = models.ForeignKey(Leak, models.CASCADE, null=True)
+
+    def __str__(self):
+        return repr(self)
+
+    def __repr__(self):
+        return '<SeaLion %s %s %s>' % (self.id, self.height, self.weight)
 
 
 class SeaLionAbstractSubclass(SeaLion):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,49 +21,49 @@ class SealableModelTests(SimpleTestCase):
     def test_sealed_instance_deferred_attribute_access(self):
         instance = SeaLion.from_db('default', ['id'], [1])
         instance.seal()
-        message = "Cannot fetch deferred field weight on sealed SeaLion object"
+        message = "Cannot fetch deferred field weight on sealed <SeaLion instance>"
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.weight
 
     def test_sealed_instance_foreign_key_access(self):
         instance = SeaLion.from_db('default', ['id', 'location_id'], [1, 1])
         instance.seal()
-        message = "Cannot fetch related field location on sealed SeaLion object"
+        message = "Cannot fetch related field location on sealed <SeaLion instance>"
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.location
 
     def test_sealed_instance_reverse_foreign_key_access(self):
         instance = Location.from_db('default', ['id'], [1])
         instance.seal()
-        message = "Cannot fetch many-to-many field visitors on sealed Location object"
+        message = "Cannot fetch many-to-many field visitors on sealed <Location instance>"
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.visitors.all()
 
     def test_sealed_instance_one_to_one_access(self):
         instance = SeaGull.from_db('default', ['id', 'sealion_id'], [1, 1])
         instance.seal()
-        message = "Cannot fetch related field sealion on sealed SeaGull object"
+        message = "Cannot fetch related field sealion on sealed <SeaGull instance>"
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.sealion
 
     def test_sealed_instance_reverse_one_to_one_access(self):
         instance = SeaLion.from_db('default', ['id'], [1])
         instance.seal()
-        message = "Cannot fetch related field gull on sealed SeaLion object"
+        message = "Cannot fetch related field gull on sealed <SeaLion instance>"
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.gull
 
     def test_sealed_instance_parent_link_access(self):
         instance = SeaLion.from_db('default', ['id'], [1])
         instance.seal()
-        message = "Cannot fetch related field greatsealion on sealed SeaLion object"
+        message = "Cannot fetch related field greatsealion on sealed <SeaLion instance>"
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.greatsealion
 
     def test_sealed_instance_reverse_parent_link_access(self):
         instance = GreatSeaLion.from_db('default', ['sealion_ptr_id'], [1])
         instance.seal()
-        message = "Cannot fetch related field sealion_ptr on sealed GreatSeaLion object"
+        message = "Cannot fetch related field sealion_ptr on sealed <GreatSeaLion instance>"
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.sealion_ptr
 
@@ -72,21 +72,21 @@ class SealableModelTests(SimpleTestCase):
             'default', ['id', 'sealion_ptr_id', 'height', 'weight', 'location_id', 'leak_id'], [1, 1, 1, 1, 1, 1]
         )
         instance.seal()
-        message = "Cannot fetch related field location on sealed SeaLion object"
+        message = "Cannot fetch related field location on sealed <SeaLion instance>"
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.sealion_ptr.location
 
     def test_sealed_instance_m2m_access(self):
         instance = SeaLion.from_db('default', ['id'], [1])
         instance.seal()
-        message = "Cannot fetch many-to-many field previous_locations on sealed SeaLion object"
+        message = "Cannot fetch many-to-many field previous_locations on sealed <SeaLion instance>"
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.previous_locations.all()
 
     def test_sealed_instance_reverse_m2m_access(self):
         instance = Location.from_db('default', ['id'], [1])
         instance.seal()
-        message = "Cannot fetch many-to-many field previous_visitors on sealed Location object"
+        message = "Cannot fetch many-to-many field previous_visitors on sealed <Location instance>"
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.previous_visitors.all()
 
@@ -104,14 +104,14 @@ class ContentTypesSealableModelTests(TestCase):
     def test_sealed_instance_generic_foreign_key(self):
         instance = Nickname.from_db('default', ['id', 'content_type_id', 'object_id'], [1, 1, 1])
         instance.seal()
-        message = "Cannot fetch related field content_object on sealed Nickname object"
+        message = "Cannot fetch related field content_object on sealed <Nickname instance>"
         with self.assertNumQueries(0), self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.content_object
 
     def test_sealed_instance_generic_relation(self):
         instance = SeaGull.from_db('default', ['id'], [1])
         instance.seal()
-        message = "Cannot fetch many-to-many field nicknames on sealed SeaGull object"
+        message = "Cannot fetch many-to-many field nicknames on sealed <SeaGull instance>"
         with self.assertNumQueries(0), self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.nicknames.all()
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -38,7 +38,7 @@ class SealableQuerySetTests(TestCase):
 
     def test_sealed_deferred_field(self):
         instance = SeaLion.objects.seal().defer('weight').get()
-        message = 'Cannot fetch deferred field weight on sealed SeaLion object'
+        message = 'Cannot fetch deferred field weight on sealed <SeaLion instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.weight
 
@@ -48,7 +48,7 @@ class SealableQuerySetTests(TestCase):
 
     def test_sealed_foreign_key(self):
         instance = SeaLion.objects.seal().get()
-        message = 'Cannot fetch related field location on sealed SeaLion object'
+        message = 'Cannot fetch related field location on sealed <SeaLion instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.location
 
@@ -60,7 +60,7 @@ class SealableQuerySetTests(TestCase):
         instance = SeaLion.objects.select_related('location').seal().get()
         self.assertEqual(instance.location, self.location)
         instance = SeaGull.objects.select_related('sealion').seal().get()
-        message = 'Cannot fetch related field location on sealed SeaLion object'
+        message = 'Cannot fetch related field location on sealed <SeaLion instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.sealion.location
         instance = SeaGull.objects.select_related('sealion__location').seal().get()
@@ -77,13 +77,13 @@ class SealableQuerySetTests(TestCase):
         ).only('sealion__location__latitude').seal().get()
         self.assertEqual(instance.sealion.location, self.location)
         self.assertEqual(instance.sealion.location.latitude, self.location.latitude)
-        message = 'Cannot fetch deferred field longitude on sealed Location object'
+        message = 'Cannot fetch deferred field longitude on sealed <Location instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.sealion.location.longitude
 
     def test_sealed_one_to_one(self):
         instance = SeaGull.objects.seal().get()
-        message = 'Cannot fetch related field sealion on sealed SeaGull object'
+        message = 'Cannot fetch related field sealion on sealed <SeaGull instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.sealion
 
@@ -97,7 +97,7 @@ class SealableQuerySetTests(TestCase):
 
     def test_sealed_many_to_many(self):
         instance = SeaLion.objects.seal().get()
-        message = 'Cannot fetch many-to-many field previous_locations on sealed SeaLion object'
+        message = 'Cannot fetch many-to-many field previous_locations on sealed <SeaLion instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.previous_locations.all()
 
@@ -110,7 +110,7 @@ class SealableQuerySetTests(TestCase):
         with self.assertNumQueries(0):
             self.assertSequenceEqual(instance.previous_locations.all(), [self.location])
         instance = instance.previous_locations.all()[0]
-        message = 'Cannot fetch many-to-many field previous_visitors on sealed Location object'
+        message = 'Cannot fetch many-to-many field previous_visitors on sealed <Location instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.previous_visitors.all()
 
@@ -121,7 +121,7 @@ class SealableQuerySetTests(TestCase):
         with self.assertNumQueries(0):
             self.assertSequenceEqual(instance.previous_locations.all(), [self.location])
         instance = instance.previous_locations.all()[0]
-        message = 'Cannot fetch many-to-many field previous_visitors on sealed Location object'
+        message = 'Cannot fetch many-to-many field previous_visitors on sealed <Location instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.previous_visitors.all()
 
@@ -132,7 +132,7 @@ class SealableQuerySetTests(TestCase):
         with self.assertNumQueries(0):
             self.assertSequenceEqual(instance.previous_locations.all(), [self.location])
         instance = instance.previous_locations.all()[0]
-        message = 'Cannot fetch many-to-many field previous_visitors on sealed Location object'
+        message = 'Cannot fetch many-to-many field previous_visitors on sealed <Location instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.previous_visitors.all()
 
@@ -144,7 +144,7 @@ class SealableQuerySetTests(TestCase):
                 instance.previous_locations.all()[0].previous_visitors.all(), [self.sealion]
             )
         instance = instance.previous_locations.all()[0].previous_visitors.all()[0]
-        message = 'Cannot fetch many-to-many field previous_locations on sealed SeaLion object'
+        message = 'Cannot fetch many-to-many field previous_locations on sealed <SeaLion instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.previous_locations.all()
 
@@ -158,7 +158,7 @@ class SealableQuerySetTests(TestCase):
                 instance.previous_locations.all()[0].previous_visitors.all(), [self.sealion]
             )
         instance = instance.previous_locations.all()[0].previous_visitors.all()[0]
-        message = 'Cannot fetch many-to-many field previous_locations on sealed SeaLion object'
+        message = 'Cannot fetch many-to-many field previous_locations on sealed <SeaLion instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.previous_locations.all()
 
@@ -168,13 +168,13 @@ class SealableQuerySetTests(TestCase):
         ).get()
         with self.assertNumQueries(0):
             self.assertSequenceEqual(instance.previous_locations.all(), [self.location])
-        message = 'Cannot fetch many-to-many field previous_visitors on sealed Location object'
+        message = 'Cannot fetch many-to-many field previous_visitors on sealed <Location instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.previous_locations.all()[0].previous_visitors.all()
 
     def test_sealed_deferred_parent_link(self):
         instance = GreatSeaLion.objects.only('pk').seal().get()
-        message = 'Cannot fetch related field sealion_ptr on sealed GreatSeaLion object'
+        message = 'Cannot fetch related field sealion_ptr on sealed <GreatSeaLion instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.sealion_ptr
 
@@ -189,7 +189,7 @@ class SealableQuerySetTests(TestCase):
 
     def test_sealed_generic_foreign_key(self):
         instance = Nickname.objects.seal().get()
-        message = 'Cannot fetch related field content_object on sealed Nickname object'
+        message = 'Cannot fetch related field content_object on sealed <Nickname instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.content_object
 
@@ -204,7 +204,7 @@ class SealableQuerySetTests(TestCase):
 
     def test_sealed_reverse_foreign_key(self):
         instance = Location.objects.seal().get()
-        message = 'Cannot fetch many-to-many field visitors on sealed Location object'
+        message = 'Cannot fetch many-to-many field visitors on sealed <Location instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.visitors.all()
 
@@ -218,7 +218,7 @@ class SealableQuerySetTests(TestCase):
 
     def test_sealed_reverse_parent_link(self):
         instance = SeaLion.objects.seal().get()
-        message = 'Cannot fetch related field greatsealion on sealed SeaLion object'
+        message = 'Cannot fetch related field greatsealion on sealed <SeaLion instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.greatsealion
 
@@ -232,7 +232,7 @@ class SealableQuerySetTests(TestCase):
 
     def test_sealed_reverse_many_to_many(self):
         instance = Location.objects.seal().get()
-        message = 'Cannot fetch many-to-many field previous_visitors on sealed Location object'
+        message = 'Cannot fetch many-to-many field previous_visitors on sealed <Location instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.previous_visitors.all()
 
@@ -246,7 +246,7 @@ class SealableQuerySetTests(TestCase):
 
     def test_sealed_generic_relation(self):
         instance = SeaGull.objects.seal().get()
-        message = 'Cannot fetch many-to-many field nicknames on sealed SeaGull object'
+        message = 'Cannot fetch many-to-many field nicknames on sealed <SeaGull instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             instance.nicknames.all()
 


### PR DESCRIPTION
Should handle the case where `__repr__`/`__unicode__`/`__str__` use unfetched columns, causing a recursion error.