### PR TITLE
Add OneToOneField example for leaking causing .seal() AttributeError.

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -34,7 +34,8 @@ class SeaLion(SealableModel):
     weight = models.PositiveIntegerField()
     location = models.ForeignKey(Location, models.CASCADE, null=True, related_name='visitors')
     previous_locations = models.ManyToManyField(Location, related_name='previous_visitors')
-    leak = models.ForeignKey(Leak, models.CASCADE, null=True)
+    leak = models.ForeignKey(Leak, models.CASCADE, null=True, related_name='sealion_just_friends')
+    leak_o2o = models.OneToOneField(Leak, models.CASCADE, null=True, related_name='sealion_soulmate')
 
     def __str__(self):
         return force_text(repr(self))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -69,7 +69,9 @@ class SealableModelTests(SimpleTestCase):
 
     def test_sealed_instance_reverse_parent_link_access_sealed(self):
         instance = GreatSeaLion.from_db(
-            'default', ['id', 'sealion_ptr_id', 'height', 'weight', 'location_id', 'leak_id'], [1, 1, 1, 1, 1, 1]
+            'default',
+            ['id', 'sealion_ptr_id', 'height', 'weight', 'location_id', 'leak_id', 'leak_o2o_id'],
+            [1, 1, 1, 1, 1, 1, 1]
         )
         instance.seal()
         message = "Cannot fetch related field location on sealed <SeaLion instance>"


### PR DESCRIPTION
Guessing we just have to make the descriptions OneToOne aware, but I wonder if a more fundamental fix might be a util like `try_sealing(obj)` that would do some `isinstance()` inspection.