### PR TITLE
Defer sealed one-to-many related manager warnings until fetching.

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,8 +41,9 @@ class SealableModelTests(SimpleTestCase):
         instance = Location.from_db('default', ['id'], [1])
         instance.seal()
         message = "Cannot fetch many-to-many field visitors on sealed <Location instance>"
+        visitors = instance.visitors.all()
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
-            instance.visitors.all()
+            list(visitors)
 
     def test_sealed_instance_one_to_one_access(self):
         instance = SeaGull.from_db('default', ['id', 'sealion_id'], [1, 1])
@@ -87,15 +88,17 @@ class SealableModelTests(SimpleTestCase):
         instance = SeaLion.from_db('default', ['id'], [1])
         instance.seal()
         message = "Cannot fetch many-to-many field previous_locations on sealed <SeaLion instance>"
+        previous_locations = instance.previous_locations.all()
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
-            instance.previous_locations.all()
+            list(previous_locations)
 
     def test_sealed_instance_reverse_m2m_access(self):
         instance = Location.from_db('default', ['id'], [1])
         instance.seal()
         message = "Cannot fetch many-to-many field previous_visitors on sealed <Location instance>"
+        previous_visitors = instance.previous_visitors.all()
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
-            instance.previous_visitors.all()
+            list(previous_visitors)
 
 
 class ContentTypesSealableModelTests(TestCase):
@@ -119,8 +122,9 @@ class ContentTypesSealableModelTests(TestCase):
         instance = SeaGull.from_db('default', ['id'], [1])
         instance.seal()
         message = "Cannot fetch many-to-many field nicknames on sealed <SeaGull instance>"
+        nicknames = instance.nicknames.all()
         with self.assertNumQueries(0), self.assertRaisesMessage(UnsealedAttributeAccess, message):
-            instance.nicknames.all()
+            list(nicknames)
 
 
 class SealableManagerTests(SimpleTestCase):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -139,7 +139,11 @@ class SealableQuerySetTests(TestCase):
         instance = SeaLion.objects.seal().get()
         message = 'Cannot fetch many-to-many field previous_locations on sealed <SeaLion instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
-            instance.previous_locations.all()
+            list(instance.previous_locations.all())
+
+    def test_sealed_many_to_many_queryset(self):
+        instance = SeaLion.objects.seal().get()
+        self.assertEqual(instance.previous_locations.get(pk=self.location.pk), self.location)
 
     def test_not_sealed_many_to_many(self):
         instance = SeaLion.objects.get()
@@ -152,7 +156,7 @@ class SealableQuerySetTests(TestCase):
         instance = instance.previous_locations.all()[0]
         message = 'Cannot fetch many-to-many field previous_visitors on sealed <Location instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
-            instance.previous_visitors.all()
+            list(instance.previous_visitors.all())
 
     def test_sealed_prefetch_prefetched_many_to_many(self):
         instance = SeaLion.objects.prefetch_related(
@@ -163,7 +167,7 @@ class SealableQuerySetTests(TestCase):
         instance = instance.previous_locations.all()[0]
         message = 'Cannot fetch many-to-many field previous_visitors on sealed <Location instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
-            instance.previous_visitors.all()
+            list(instance.previous_visitors.all())
 
     def test_sealed_prefetch_queryset_prefetched_many_to_many(self):
         instance = SeaLion.objects.prefetch_related(
@@ -174,7 +178,7 @@ class SealableQuerySetTests(TestCase):
         instance = instance.previous_locations.all()[0]
         message = 'Cannot fetch many-to-many field previous_visitors on sealed <Location instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
-            instance.previous_visitors.all()
+            list(instance.previous_visitors.all())
 
     def test_sealed_string_prefetched_nested_many_to_many(self):
         instance = SeaLion.objects.prefetch_related('previous_locations__previous_visitors').seal().get()
@@ -186,7 +190,7 @@ class SealableQuerySetTests(TestCase):
         instance = instance.previous_locations.all()[0].previous_visitors.all()[0]
         message = 'Cannot fetch many-to-many field previous_locations on sealed <SeaLion instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
-            instance.previous_locations.all()
+            list(instance.previous_locations.all())
 
     def test_sealed_prefetch_prefetched_nested_many_to_many(self):
         instance = SeaLion.objects.prefetch_related(
@@ -200,7 +204,7 @@ class SealableQuerySetTests(TestCase):
         instance = instance.previous_locations.all()[0].previous_visitors.all()[0]
         message = 'Cannot fetch many-to-many field previous_locations on sealed <SeaLion instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
-            instance.previous_locations.all()
+            list(instance.previous_locations.all())
 
     def test_prefetched_sealed_many_to_many(self):
         instance = SeaLion.objects.prefetch_related(
@@ -210,7 +214,7 @@ class SealableQuerySetTests(TestCase):
             self.assertSequenceEqual(instance.previous_locations.all(), [self.location])
         message = 'Cannot fetch many-to-many field previous_visitors on sealed <Location instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
-            instance.previous_locations.all()[0].previous_visitors.all()
+            list(instance.previous_locations.all()[0].previous_visitors.all())
 
     def test_sealed_deferred_parent_link(self):
         instance = GreatSeaLion.objects.only('pk').seal().get()
@@ -246,7 +250,7 @@ class SealableQuerySetTests(TestCase):
         instance = Location.objects.seal().get()
         message = 'Cannot fetch many-to-many field visitors on sealed <Location instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
-            instance.visitors.all()
+            list(instance.visitors.all())
 
     def test_not_sealed_reverse_foreign_key(self):
         instance = Location.objects.get()
@@ -274,7 +278,11 @@ class SealableQuerySetTests(TestCase):
         instance = Location.objects.seal().get()
         message = 'Cannot fetch many-to-many field previous_visitors on sealed <Location instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
-            instance.previous_visitors.all()
+            list(instance.previous_visitors.all())
+
+    def test_sealed_reverse_many_to_many_queryset(self):
+        instance = Location.objects.seal().get()
+        self.assertEqual(instance.previous_visitors.get(pk=self.sealion.pk), self.sealion)
 
     def test_not_reverse_sealed_many_to_many(self):
         instance = Location.objects.get()
@@ -288,7 +296,7 @@ class SealableQuerySetTests(TestCase):
         instance = SeaGull.objects.seal().get()
         message = 'Cannot fetch many-to-many field nicknames on sealed <SeaGull instance>'
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
-            instance.nicknames.all()
+            list(instance.nicknames.all())
 
     def test_not_sealed_generic_relation(self):
         instance = SeaGull.objects.get()


### PR DESCRIPTION
This allows using one-to-many related manager to refine filtering or perform manipulations such add, remove, clear, and set.

Fixes #35.