### PR TITLE
Based sealable managers of Manager instead of BaseManager.

### DIFF
--- a/seal/models.py
+++ b/seal/models.py
@@ -9,7 +9,7 @@ from .descriptors import sealable_descriptor_classes
 from .query import SealableQuerySet
 
 
-class BaseSealableManager(models.manager.BaseManager):
+class BaseSealableManager(models.manager.Manager):
     def check(self, **kwargs):
         errors = super(BaseSealableManager, self).check(**kwargs)
         if not issubclass(self.model, SealableModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -128,6 +128,11 @@ class ContentTypesSealableModelTests(TestCase):
 
 
 class SealableManagerTests(SimpleTestCase):
+    def test_isinstance_manager(self):
+        """Manager classes are subclasses of Manager as many third-party apps expect."""
+        self.assertIsInstance(SealableManager(), models.Manager)
+        self.assertIsInstance(SealableQuerySet.as_manager(), models.Manager)
+
     @isolate_apps('tests')
     def test_non_sealable_model(self):
         class Foo(models.Model):


### PR DESCRIPTION
A lot of third-party apps expects the former instead of the latter in the inheritance chain.

/cc @PCManticore