### PR TITLE
Greatly reduce complexity of prefetch related queries sealing.

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -10,6 +10,7 @@ from django.test.utils import isolate_apps
 
 from seal.descriptors import _SealedRelatedQuerySet
 from seal.exceptions import UnsealedAttributeAccess
+from seal.models import make_model_sealable
 from seal.query import SealableQuerySet, SealedModelIterable
 
 from .models import (
@@ -382,7 +383,7 @@ class SealableQuerySetInteractionTests(SimpleTestCase):
 
 class SealableQuerySetNonSealableModelTests(TestCase):
     """
-    A SealableQuerySet should be usuable on non SealableModel subclasses.
+    A SealableQuerySet should be usable on non SealableModel subclasses.
     """
     @classmethod
     def setUpTestData(cls):
@@ -436,6 +437,7 @@ class SealableQuerySetNonSealableModelTests(TestCase):
 
             class Meta:
                 db_table = Location._meta.db_table
+        make_model_sealable(NonSealableLocation)
         queryset = SealableQuerySet(model=NonSealableLocation)
         instance = queryset.prefetch_related('climates').seal().get()
         self.assertTrue(instance._state.sealed)


### PR DESCRIPTION
Use the get_prefetch_queryset hook instead of converting all string referencse
passed to prefetch_related into Prefetch objects with a .seal()'ed queryset.

This has the side effect of breaking support for SealableQueryset.seal() of
relationships when used on a non-sealable model but I think it's worth doing.
The previous behavior can be restored by making the model sealable using the
make_model_sealable function.