### PR TITLE
Track cardinality of querysel seal.

### DIFF
--- a/seal/constants.py
+++ b/seal/constants.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class Seal(Enum):
+    SINGLE = 'single'
+    MULTIPLE = 'multiple'

--- a/seal/models.py
+++ b/seal/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.db.models.fields.related import lazy_related_operation
 from django.dispatch import receiver
 
+from .constants import Seal
 from .descriptors import sealable_descriptor_classes
 from .query import SealableQuerySet
 
@@ -43,12 +44,12 @@ class SealableModel(models.Model):
     class Meta:
         abstract = True
 
-    def seal(self):
+    def seal(self, seal=Seal.SINGLE):
         """
         Seal the instance to turn deferred and related fields access that would
         required fetching from the database into exceptions.
         """
-        self._state.sealed = True
+        self._state.seal = seal
 
 
 def make_descriptor_sealable(model, attname):

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     author_email='simon.charette@zapier.com',
     install_requires=[
         'Django>=1.11',
+        'enum34;python_version<"3.4"',
     ],
     packages=find_packages(exclude=['tests', 'tests.*']),
     license='MIT License',


### PR DESCRIPTION
This will allow to differentiate between sealed queryset that would benefit from prefetching many-to-many relationships and the ones that don't.

In other words, warning about N+1 query issues when fetching a many-to-many relationship from a singular result (.get(), .first()) is arguably bad practice as it could be beneficial to defer the fetching. This is a common scenario when seal()'ing a queryset meant to be used both by singular (detail view) and multiple results (list view) code paths.

---

This paves the way for addressing #44 but it will likely need to be opt-in through a setting to maintain backward compatibility.