### PR TITLE
Address a crash when dealing with self-referential many-to-many descriptors.

### DIFF
--- a/seal/models.py
+++ b/seal/models.py
@@ -72,6 +72,9 @@ def make_remote_field_descriptor_sealable(model, related_model, remote_field):
     if not issubclass(related_model, SealableModel):
         return
     accessor_name = remote_field.get_accessor_name()
+    # Self-referential many-to-many fields don't have a reverse accessor.
+    if accessor_name is None:
+        return
     make_descriptor_sealable(related_model, accessor_name)
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -29,6 +29,7 @@ class Location(SealableModel):
     latitude = models.FloatField()
     longitude = models.FloatField()
     climates = models.ManyToManyField(Climate, blank=True, related_name='locations')
+    related_locations = models.ManyToManyField('self')
 
 
 class Island(models.Model):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -101,6 +101,14 @@ class SealableModelTests(SimpleTestCase):
         with self.assertRaisesMessage(UnsealedAttributeAccess, message):
             list(previous_visitors)
 
+    def test_sealed_instance_self_referential_m2m_acccess(self):
+        instance = Location.from_db('default', ['id'], [1])
+        instance.seal()
+        message = 'Attempt to fetch many-to-many field "related_locations" on sealed <Location instance>'
+        previous_visitors = instance.related_locations.all()
+        with self.assertRaisesMessage(UnsealedAttributeAccess, message):
+            list(previous_visitors)
+
 
 class ContentTypesSealableModelTests(TestCase):
     @classmethod


### PR DESCRIPTION
Many-to-many symmetrical relationships don't have reverse accessors.

Fix #50.