### PR TITLE
Fix #58 -- Properly handle related descriptors get_prefetch_queryset overrides.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+1.4.2
+=====
+:release-date: 2021-04-05
+
+- Properly handled related descriptors ``get_prefetch_queryset`` overrides (#58)
+
 1.4.1
 =====
 :release-date: 2021-03-30

--- a/seal/descriptors.py
+++ b/seal/descriptors.py
@@ -46,10 +46,11 @@ class _SealedRelatedQuerySet(QuerySet):
 
 class SealedPrefetchMixin(object):
     def get_prefetch_queryset(self, instances, queryset=None):
-        prefetch = super(SealedPrefetchMixin, self).get_prefetch_queryset(instances, queryset)
-        if getattr(instances[0]._state, 'sealed', False) and isinstance(prefetch[0], SealableQuerySet):
-            prefetch = (prefetch[0].seal(),) + prefetch[1:]
-        return prefetch
+        if queryset is None:
+            queryset = self.get_queryset()
+        if getattr(instances[0]._state, 'sealed', False) and isinstance(queryset, SealableQuerySet):
+            queryset = queryset.seal()
+        return super().get_prefetch_queryset(instances, queryset)
 
 
 @lru_cache(maxsize=100)

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -62,6 +62,12 @@ class Migration(migrations.Migration):
                         blank=True, related_name='locations', to='tests.Climate'
                     ),
                 ),
+                (
+                    'related_locations',
+                    models.ManyToManyField(
+                        blank=True, to='tests.Location'
+                    ),
+                ),
             ],
             options={'abstract': False},
         ),

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -357,6 +357,17 @@ class SealableQuerySetTests(TestCase):
                 [self.location]
             )
 
+    def test_sealed_related_prefetch_relate_results_cache(self):
+        """Some related managers fetch objects in get_prefetch_queryset()."""
+        location_relations = ['climates', 'related_locations', 'visitors']
+        for relation in location_relations:
+            with self.subTest(relation=relation), self.assertNumQueries(2):
+                list(Location.objects.seal().prefetch_related(relation).all())
+        sea_lion_relations = ['location', 'previous_locations', 'leak', 'leak_o2o']
+        for relation in sea_lion_relations:
+            with self.subTest(relation=relation), self.assertNumQueries(2):
+                list(SeaLion.objects.seal().prefetch_related(relation).all())
+
 
 class SealableQuerySetInteractionTests(SimpleTestCase):
     def test_values_seal_disallowed(self):


### PR DESCRIPTION
Related descriptors happen to return cached querysets in `get_prefetch_queryset` since Django 2.2. By making sure to seal queryset before calling the default implementation we ensure only a single query is performed.

---

@renetta96 could you confirm this addresses the issue reported in #58?